### PR TITLE
Adicionado suporte ao Homestead

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@ public/build
 public/css
 public/fonts
 /.idea
+/.vagrant
+Homestead.yaml

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,28 @@
+require 'json'
+require 'yaml'
+
+VAGRANTFILE_API_VERSION ||= "2"
+confDir = $confDir ||= File.expand_path("vendor/laravel/homestead", File.dirname(__FILE__))
+
+homesteadYamlPath = "Homestead.yaml"
+homesteadJsonPath = "Homestead.json"
+afterScriptPath = "after.sh"
+aliasesPath = "aliases"
+
+require File.expand_path(confDir + '/scripts/homestead.rb')
+
+Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
+    if File.exists? aliasesPath then
+        config.vm.provision "file", source: aliasesPath, destination: "~/.bash_aliases"
+    end
+
+    if File.exists? homesteadYamlPath then
+        Homestead.configure(config, YAML::load(File.read(homesteadYamlPath)))
+    elsif File.exists? homesteadJsonPath then
+        Homestead.configure(config, JSON.parse(File.read(homesteadJsonPath)))
+    end
+
+    if File.exists? afterScriptPath then
+        config.vm.provision "shell", path: afterScriptPath
+    end
+end

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,8 @@
         "mockery/mockery": "0.9.*",
         "phpunit/phpunit": "~4.0",
         "phpspec/phpspec": "~2.1",
-        "artesaos/warehouse": "2.x-dev"
+        "artesaos/warehouse": "2.x-dev",
+        "laravel/homestead": "^2.1"
     },
     "autoload": {
         "classmap": [

--- a/readme.md
+++ b/readme.md
@@ -1,16 +1,51 @@
 ## Laravel Brasil Forum [WIP]
 
-### Setup commands
+## Instalação utilizando Homestead
+
+O fórum já possui o Homestead como dependência, mas ainda é necessário ajustar as configurações do projeto na máquina de desenvolvimento. Primeiramente devemos criar o arquivo `Homestead.yaml` com o comando:
+
+```shell
+php vendor/bin/homestead make
+```
+
+Por padrão o Laravel irá mapear a pasta atual para o domínio `homestead.app`. Caso deseje outro domínio basta alterar a sessão sites no arquivo `Homestead.yaml`, lembrando que ainda é necessário apontar o domínio para a máquina virtual no arquivo `/etc/hosts`. Por exemplo:
+
+``` 
+192.168.10.10    homestead.app
+```
+
+Feito isso basta iniciar a máquina virtual e rodar as migrações do projeto:
+
+```shell
+vagrant up
+vagrant ssh
+cd <project_dir>
+
+composer install
+npm install
+bower install
+gulp
+cp .env.example .env
+php artisan key:generate
+php artisan migrate
+```
+
+### Instalação sem o Homestead
 
 ```shell
 composer install
 npm install
 bower install
 gulp
+cp .env.example .env
+php artisan key:generate
 ```
+
+Para acessar o banco de dados é necessário possuir o mysql instalado na máquina e configurar o acesso no arquivo `.env`. Feito isso basta rodar as migrações e iniciar o servidor:
 
 ```shell
 php artisan migrate --seed
+php artisan serve
 ```
 
 ### Hangouts


### PR DESCRIPTION
Adicionado suporte ao Homestead para os desenvolvedores que desejarem
utilizar uma máquina virtual para desenvolvimento. Também foi adicionado
ao readme.md as instruções de instalação e configuração.
